### PR TITLE
fixed delete sgf not working on some sgfs, needed to allownull to be …

### DIFF
--- a/backend/db/migrations/03-create-puzzle.js
+++ b/backend/db/migrations/03-create-puzzle.js
@@ -19,7 +19,8 @@ module.exports = {
           type: Sequelize.INTEGER,
         },
         sgf_id: {
-          allowNull: false,
+          // Allow null true so we can set this to be null when we delete the sgf without deleting the associated puzzles, otherwise we get a foreign key constraint failed
+          allowNull: true,
           type: Sequelize.INTEGER,
           // remember "model" here is actually "table" lol
           references: { model: "Sgfs", key: "id" },

--- a/backend/db/models/puzzle.js
+++ b/backend/db/models/puzzle.js
@@ -16,7 +16,7 @@ module.exports = (sequelize, DataTypes) => {
   Puzzle.init(
     {
       sgf_id: {
-        allowNull: false,
+        allowNull: true,
         type: DataTypes.INTEGER,
       },
       sgf_data: {
@@ -116,7 +116,15 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false,
         type: DataTypes.TEXT,
         get() {
-          return JSON.parse(this.getDataValue('solution_coordinates'));
+          const val = this.getDataValue('solution_coordinates');
+          if (!val) return null;
+
+          try {
+            return JSON.parse(val);
+          } catch (err) {
+            console.error("JSON parsing failed:", err);
+            return null;
+          }
         },
         set(val) {
           this.setDataValue('solution_coordinates', JSON.stringify(val));

--- a/backend/db/models/sgf.js
+++ b/backend/db/models/sgf.js
@@ -6,7 +6,7 @@ const { Model } = require("sequelize");
 module.exports = (sequelize, DataTypes) => {
   class Sgf extends Model {
     static associate(models) {
-      Sgf.hasMany(models.Puzzle, { foreignKey: "sgf_id" });
+      Sgf.hasMany(models.Puzzle, { foreignKey: "sgf_id", onDelete: 'SET NULL'  });
       Sgf.belongsTo(models.User, { foreignKey: "user_id" });
     }
   }

--- a/backend/routes/api/puzzles.js
+++ b/backend/routes/api/puzzles.js
@@ -275,9 +275,7 @@ router.put("/:puzzle_id", requireAuth, async (req, res) => {
     }
 
     if (difficulty < 100 || difficulty > 5000) {
-      errors.difficulty = [
-        "Rank must be between 100 and 5000.",
-      ];
+      errors.difficulty = ["Rank must be between 100 and 5000."];
     }
 
     if (/^\s*$/.test(description)) {
@@ -335,6 +333,28 @@ router.put("/:puzzle_id", requireAuth, async (req, res) => {
     return res
       .status(500)
       .json({ error: "An error occurred while editing the puzzle" });
+  }
+});
+
+// Delete a public puzzle (suspend it later)
+
+router.delete("/:puzzle_id", requireAuth, async (req, res) => {
+  try {
+    // Find the specified puzzle by puzzle id in the url
+    const puzzle = await Puzzle.findOne({
+      where: { id: req.params.puzzle_id },
+    });
+
+    if (!puzzle) {
+      return res.status(404).json({ message: "Puzzle couldn't be found" });
+    }
+
+    await puzzle.destroy();
+
+    return res.status(200).json({ message: "Successfully delete Puzzle!" });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "Internal Server Error!" });
   }
 });
 

--- a/backend/routes/api/sgfs.js
+++ b/backend/routes/api/sgfs.js
@@ -398,6 +398,7 @@ router.delete("/:sgf_id", requireAuth, async (req, res) => {
       return res.status(403).json({ message: "Not authorized!" });
     }
 
+    await Puzzle.update({ sgf_id: null }, { where: { sgf_id: req.params.sgf_id } });
     // Delete the SGF record
     await sgfRecord.destroy();
 


### PR DESCRIPTION
…true on sgf_id in migration and model of puzzle, then we set the puzzle's sgf_id to null when we delete, so we avoid the foreign key constraint failed violation, also, changed the getter method in puzzle's solution coordinates, lastly, started delete public puzzle by id endpoint