### PR TITLE
updated backend get all sgfs endpoint to include a boolean indicating…

### DIFF
--- a/backend/routes/api/sgfs.js
+++ b/backend/routes/api/sgfs.js
@@ -45,11 +45,19 @@ router.get("/", requireAuth, async (req, res) => {
     where: { user_id: req.user.id, suspended: false },
   });
 
+  // Fetch SGF IDs from potential puzzles so that we can conditionally disable the "Generate Puzzles" button based on whether the potential puzzles were already generated
+  const potentialPuzzleSGFIds = await PotentialPuzzle.findAll({
+    where: { /* your conditions, if any */ },
+    attributes: ['sgf_id'],
+    raw: true
+  }).then(puzzles => puzzles.map(puzzle => puzzle.sgf_id)); // return true or false boolean value based on if potential puzzles for that sgf_id already exist
+
   const formattedSGFs = {
     SGFs: sgfs.map((sgf) => ({
       ...sgf.get(),
       board_size: Number(sgf.board_size), // converting to Number type
       game_date: moment(sgf.game_date).format("YYYY-MM-DD HH:mm:ss"),
+      hasPotentialPuzzle: potentialPuzzleSGFIds.includes(sgf.id), // boolean indicating if that specific sgf has already generated potential puzzles, in which case we will render a disabled generate puzzles button instead
       createdAt: moment(sgf.createdAt).format("YYYY-MM-DD HH:mm:ss"),
       updatedAt: moment(sgf.updatedAt).format("YYYY-MM-DD HH:mm:ss"),
     })),

--- a/frontend/src/components/UserSGFs.js
+++ b/frontend/src/components/UserSGFs.js
@@ -114,6 +114,16 @@ const UserSGFs = () => {
 
   // console.log("*****************", localTimezoneOffsetHours)
 
+
+    // // Function to check if SGF ID exists in potential_puzzles
+    // const isSGFIDGenerated = (sgfId) => {
+    //   return potentialPuzzles.some(puzzle => puzzle.sgf_id === sgfId);
+    // };
+
+    // // Check if the current SGF ID is in the potential puzzles
+    // const sgfGenerated = isSGFIDGenerated(sgf.id);
+
+
   return (
     <div className="outer-wrapper">
       <div className="upload-sgf-button">
@@ -172,9 +182,11 @@ const UserSGFs = () => {
                       {formatDate(sgf.updatedAt)}
                     </div>
                     <button
-                      className="create-puzzles-button button-hover"
+                      className={`create-puzzles-button button-hover`}
+                      // className={`create-puzzles-button button-hover ${sgfGenerated ? 'ghosted-button' : ''}`}
                       onClick={() => handleGeneratePuzzles(sgf)}
-                      disabled={isLoading === "GENERATING_PUZZLES"}
+                      disabled={ isLoading === "GENERATING_PUZZLES"}
+                      // disabled={sgfGenerated || isLoading === "GENERATING_PUZZLES"}
                     >
                       Generate Puzzles!
                     </button>

--- a/frontend/src/components/styles/UserSGFs.css
+++ b/frontend/src/components/styles/UserSGFs.css
@@ -49,6 +49,14 @@
   margin-bottom: 10px;
 }
 
+/* Ghosted out Generate puzzles button styling */
+
+.ghosted-button {
+  opacity: 0.5; /* Makes the button look faded */
+  pointer-events: none; /* Prevents clicking */
+  cursor: default; /* Changes cursor to indicate it's not clickable */
+}
+
 .generate-puzzles-feature-text {
   margin-top: 10px;
   color: aliceblue;


### PR DESCRIPTION
… whether or not potential puzzles have already been generated successfully for the given sgf (based on sgF_id), if it has, we will render the generate puzzles button under each sgf as a disabled button and ghost it out