### PR TITLE
wrote comment at bottom of convert_to_AB_AW script, with observation …

### DIFF
--- a/katago/convert_to_AB_AW.py
+++ b/katago/convert_to_AB_AW.py
@@ -135,3 +135,7 @@ def process_sgf_data(input_data):
 
 # # For a list of sgf_data strings
 # converted_data_list = process_sgf_data(list_of_sgf_data_strings)
+
+# ***** 12/19/2023 Start debug issue with OGS 1 stone handicap causing the AB AW to fail?
+# Looks like it properly creates the 1 line json, and cleans and adds comments to the sgf strings (should verify this), but
+# the convert_to_AB_AW fails, I'm guessing this has to do with the extra AB that is added at the start of the sgfString?


### PR DESCRIPTION
…for debugging a very specific OGS sgf record that is failing to generate potential puzzles, it's throwing a 500 internal server error, need to verify sgf strings are valid, then will go line by line through the script