### PR TITLE
found various bugs with the filter puzzles feature, bad data (move_nu…

### DIFF
--- a/backend/routes/api/potential_puzzles.js
+++ b/backend/routes/api/potential_puzzles.js
@@ -67,7 +67,7 @@ router.post("/:sgf_id/katago_json_input", requireAuth, async (req, res) => {
   }
 });
 
-// Trigger KataGo analysis LOCALLY only, GCP VM is at the endpoint found in the VM itself!!!!
+// Trigger KataGo analysis LOCALLY only, go to folder google_cloud_setup and then katago-server.js to change that endpoint
 router.post("/generate", requireAuth, async (req, res) => {
   try {
     const { sgf_id, sgf_data, one_line_json_string } = req.body;
@@ -355,7 +355,6 @@ router.get("/:sgf_id", requireAuth, async (req, res) => {
 router.post("/store_vm_results", async (req, res) => {
   try {
     const potential_puzzles = req.body.createdPuzzles;
-
     const category = "other";
     const difficulty = 1500;
 
@@ -363,17 +362,6 @@ router.post("/store_vm_results", async (req, res) => {
 
     for (const puzzle of potential_puzzles) {
       const { sgf_id, sgf_data, move_number } = puzzle;
-
-      // Check if 'pass' is in the keys or values of solution_coordinates, these are invalid puzzles
-      // const hasPass =
-      //   Object.keys(solution_coordinates).includes("pass") ||
-      //   Object.values(solution_coordinates).some((value) =>
-      //     value.includes("pass")
-      //   );
-
-      // if (hasPass) {
-      //   continue;
-      // }
 
       // Convert solution_coordinates object to string for storing in database
       const solution_coordinates_string = JSON.stringify(

--- a/google_cloud_setup/katago-server.js
+++ b/google_cloud_setup/katago-server.js
@@ -34,6 +34,23 @@ app.post("/potential_puzzles/generate", async (req, res) => {
       await GCP_sgf_to_largest_mistakes.run_katago_analysis(jsonEncodedString)
     );
 
+    // // Import setting initial potential puzzle ranking script and then use it (Add the code to the VM and use a DIFFERENT PATH!)
+    // const sgf_mill_set_initial_potential_puzzle_ranking = await python(
+    //   path.join(
+    //     __dirname,
+    //     "..",
+    //     "..",
+    //     "utils",
+    //     "sgf_mill_set_initial_potential_puzzle_ranking.py"
+    //   )
+    // );
+
+    // const set_potential_puzzle_rank =
+    //   await sgf_mill_set_initial_potential_puzzle_ranking.set_potential_puzzle_difficulty(
+    //     sgf_data
+    //   );
+
+    // const difficulty = set_potential_puzzle_rank; // Setting difficulty column in potential puzzle table to the difficulty found using our python script above (determines ranking based on player's ranks)
     const category = "other";
     const difficulty = 1500;
 


### PR DESCRIPTION
…mber) incorrect when generated for some reason, and difficulty is hard coded on Google Cloud VM still (works locally), need to temporarily create an endpoint and change the frontend to allow the move_number to get manually edited? It's a huge hassle, then I have to manually look through 300 puzzles to change it too... back arrow and hard refresh after filtered puzzles renders more puzzles for some reason